### PR TITLE
handle null where list is expected

### DIFF
--- a/src/main/scala/co.blocke.ScalaJack/fields/ListField.scala
+++ b/src/main/scala/co.blocke.ScalaJack/fields/ListField.scala
@@ -45,10 +45,10 @@ case class ListField( name:String, subField:Field ) extends Field {
 	}
 	override private[scalajack] def readValue[T]( jp:JsonParser, ext:Boolean, hint:String, cc:ClassContext )(implicit m:Manifest[T]) : Any = {
 		// Token now sitting on '[' so advance and read list
-		if( jp.getCurrentToken != JsonToken.START_ARRAY) throw new IllegalArgumentException("Class "+cc.className+" field "+cc.fieldName+" Expected '['")
+		if( jp.getCurrentToken != JsonToken.START_ARRAY && jp.getCurrentToken != JsonToken.VALUE_NULL) throw new IllegalArgumentException("Class "+cc.className+" field "+cc.fieldName+" Expected '['")
 		jp.nextToken
 		val fieldData = scala.collection.mutable.ListBuffer[Any]()
-		while( jp.getCurrentToken != JsonToken.END_ARRAY ) {
+		while( jp.getCurrentToken != JsonToken.END_ARRAY && jp.getCurrentToken != null) {
 			fieldData += subField.readValue(jp, ext, hint, cc)
 		}
 		jp.nextToken

--- a/src/test/scala/co.blocke.ScalaJack/TestSpec.scala
+++ b/src/test/scala/co.blocke.ScalaJack/TestSpec.scala
@@ -164,6 +164,11 @@ class TestSpec extends FunSpec with GivenWhenThen with BeforeAndAfterAll {
 				val o = ScalaJack.read[Map[String,Long]](js)
 				o should equal( Map("a"->5L,"b"->0) )
 			}
+			it( "Handles null values - List" ) {
+				val js = """null"""
+				val o = ScalaJack.read[List[String]](js)
+				o should equal(List())
+			}
 		}
 		describe("Trait Support") {
 			it( "Traits with subclasses" ) {


### PR DESCRIPTION
Some of our feeds (FOX) have 'null' where a list is otherwise expected. This is a suggested fix to potentially handle this in ScalaJack.
