### PR TITLE
Fix bug for case class analyize when a companion object exists

### DIFF
--- a/core/src/main/scala/co.blocke.scalaJack/Analyzer.scala
+++ b/core/src/main/scala/co.blocke.scalaJack/Analyzer.scala
@@ -106,7 +106,7 @@ object Analyzer {
 						val mod     = sym.asClass.companion.asModule
 						val im      = cm.reflect(cm.reflectModule(mod).instance)
 						val ts      = im.symbol.typeSignature
-						val mApply  = ts.member(TermName("apply")).asMethod
+						val mApply  = ts.members.toList.find(m => m.name.toString == "apply" && m.isSynthetic).get.asMethod
 						val syms    = mApply.paramLists.flatten
 						val members = syms.zipWithIndex.map { case (p, i) =>
 							val fType = relativeToTrait.flatMap( _.paramMap.get(p.name.toString) )

--- a/core/src/test/scala/co.blocke.scalaJack/v4/SimpleModel.scala
+++ b/core/src/test/scala/co.blocke.scalaJack/v4/SimpleModel.scala
@@ -135,6 +135,9 @@ trait Pet {
 case class NicePet(kind:Animal, food:String) extends Pet
 case class GrumpyPet(kind:Animal, food:String) extends Pet
 
+object WithDefaults {
+	def apply(s:String):WithDefaults = WithDefaults("a",3,None)
+}
 case class WithDefaults(
 	name     : String,
 	age      : Int = 50,


### PR DESCRIPTION
If a companion object with an apply method exists for a case class the new analyze code installed in 4.4.3 to handle default values would find 2 apply methods: one in the case class and one in the companion object.  This confused it and it would crash.  This fix sorts things out.