### PR TITLE
Reimagined custom read-render output for value classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,15 +97,13 @@ Note how you get different type hints for specific traits.  This can be invaluab
 
 # Custom Value Class JSON
 
-(**NOTE:**  Custom value class JSON handling has changed since ScalaJack 3.x.  In some ways its more limited but also much simpler.)
-
-Many JSON parsers have the ability to perform custom generations/parsings for fields or data types.  Adding this feature in the conventional way would slow down the parser quite a lot, so ScalaJack does something a little different using an optional "mode" for value classes that allows you to read/render custom JSON for them.  Let's demonstrate via an example.
+(**NOTE:**  Custom value class JSON handling has changed since ScalaJack 4.7.  We no longer use the VisitorContext.)
 
 Let's imagine we have a value class PosixDate that has a long as its single value type, holding a Unix timestamp.  Let's further assume we use this class in a case class for server stats like this:
 
 ```scala
-class PosixDate( val ts:Long = (new Date()).getTime/1000 ) extends AnyVal {
-	def toDate : Date = new Date(ts*1000)
+class PosixDate( val ts:Long = (new Date()).getTime ) extends AnyVal {
+	def toDate : Date = new Date(ts)
 	def isBefore( pd:PosixDate ) = this.ts < pd.ts
 	def isAfter( pd:PosixDate )  = this.ts > pd.ts
 	override def toString() = ts.toString
@@ -120,17 +118,42 @@ val ss = ServerStats( "admin", new PosixDate() )
 val js = sj.render( ss )  // Output: {"instanceName":"admin","upSince":1383317215}
 ```
 
-For my use, though, I might want a specific format for my timestamp in the JSON.  I can accomplish this by handling custom JSON for my value classes using another field of VisitorContext, like this:
+Hmm... For my use I might want something different than that Long numeric output.  I may want a specific format for my timestamp in the JSON.  I can accomplish this by providing a companion object to my value class that extends a special trait, **ValueClassCustom**.  This trait defines read and render functions as PartialFunctions, which allows you to provide whatever reading or rendering logic you need for a given "flavor" of parsing. 
+
+The two flavors supported to day are:  **JsonKind** and **MongoKind**
+
 
 ```scala
-val handler = ValClassHandler(
-	(s) => DateTimeFormat.forPattern("MMMM, yyyy").parseDateTime(s),
-	(v) => '"'+DateTimeFormat.forPattern("MMMM, yyyy").print(v.asInstanceOf[DateTime])+'"'
-)
-val vc = VisitorContext(valClassMap = Map("com.myproj.PosixDate"->handler))
-val js = sj.render(ss,vc) // Output: {"instanceName":"admin","upSince":"November, 2013"}
+object PosixDate extends ValueClassCustom {
+  def read:PartialFunction[(KindMarker,_), Long] = {
+	  case (j:JsonKind,js:String) => 
+		  DateTimeFormat.forPattern("MMMM, yyyy").parseDateTime(js).toDate.getTime
+  }
+  def render:PartialFunction[(KindMarker,_),Any] = {
+	  case (j:JsonKind,pd:Long) => 
+		  '"'+DateTimeFormat.forPattern("MMMM, yyyy").print( new DateTime( new java.util.Date(pd)) )+'"'
+  }
+}
 ```
-The handler consists of 2 functions: one that accepts a string (for reads) and produces the appropriate object, presumably with whatever necessary manipulations you wish on the string, and another function for renders that accepts an object from your value class and produces whatever string value you wish for the JSON.
+Admittedly, the date formatting code here is a bit tortured, but to prove a point.  You'd use it like this:
+```scala
+  val sj = ScalaJack()
+  val one = ServerStats("Admin", new PosixDate)
+  println("1: "+one)
+  val js = sj.render(one)  // outputs {"instanceName":"Admin","upSince":"July, 2016"}
+  println("2: "+js)
+  println("3: "+sj.read[ServerStats](js))
+```
+The Long (the internal representation of your PosixDate value class) is successfully read and rendered using whatever formatting rules you specify.
+
+Some tips:
+
+ - For JSON parsing the first element of the tuple in read is JsonKind,
+   and the second is a String (the raw JSON value).
+ - For rendering JSON, the second tuple element of render is the internal data type, or Long
+   in our example. 
+ - For rendering JSON note that quotes are included in    the result. 
+   If your value was numeric or boolean you wouldn't need    these.
 
 # MongoDB Persistence
 

--- a/TODO
+++ b/TODO
@@ -1,6 +1,0 @@
-TODO
-----
-
-[ ] UUID support for MySQL module
-[ ] Joda DateTime support for MySQL module
-[ ] Explore List and Map support for MySQL (lazy and immediate loading)

--- a/core/src/main/scala/co.blocke.scalaJack/Model.scala
+++ b/core/src/main/scala/co.blocke.scalaJack/Model.scala
@@ -46,7 +46,18 @@ case class CollType(name:String, colTypes:List[AType]) extends AType {
 }
 
 case class EnumType(name:String, enum:Enumeration) extends AType { def dup = this.copy() }
-case class ValueClassType(name:String, vcType:AType, vFieldName:String, isTypeParam:Boolean) extends AType { def dup = this.copy() }
+case class ValueClassType(name:String, vcType:AType, vFieldName:String, isTypeParam:Boolean, custom:Option[VCCustomMethods]) extends AType { def dup = this.copy() }
+
+trait ValueClassCustom extends Any {
+	def read:PartialFunction[(KindMarker,_), Any]    // [(JackFlavor[S],S),ValueClassInstance]
+	def render:PartialFunction[(KindMarker,_), Any]  // [(JackFlavor[S],ValueClassInstance), S]
+}
+case class VCCustomMethods(
+	read:PartialFunction[(KindMarker,_), Any],
+	render:PartialFunction[(KindMarker,_), Any]
+	)
+
+trait KindMarker
 
 case class TraitType(
 	name     : String, 
@@ -55,11 +66,6 @@ case class TraitType(
 	default  : Option[Any]=None
 ) extends AType { 
 	def dup = this.copy() 
-}
-
-trait CustomType extends AType {
-	val readers   : Map[String, (Any => Any)]
-	val renderers : Map[String, (Any => Any)]
 }
 
 case class ErrType(name:String = "Error") extends AType { 

--- a/core/src/main/scala/co.blocke.scalaJack/VisitorContext.scala
+++ b/core/src/main/scala/co.blocke.scalaJack/VisitorContext.scala
@@ -9,7 +9,6 @@ case class VisitorContext(
 	isCanonical      : Boolean = true,    // allow non-string keys in Maps--not part of JSON spec
 	isValidating     : Boolean = false,
 	estFieldsInObj   : Int     = 1024,
-	valClassHandlers : Map[String,Map[String,ValClassHandler]] = Map.empty[String,Map[String,ValClassHandler]],
 	hintMap          : Map[String,String] = Map("default" -> "_hint"),  // per-class type hints (for nested classes)
 	hintValueRead    : Map[String,(String)=>String] = Map.empty[String,(String)=>String], // per-class type hint value -> class name
 	hintValueRender  : Map[String,(String)=>String] = Map.empty[String,(String)=>String]  // per-class type class name -> hint value

--- a/core/src/test/scala/co.blocke.scalaJack/v4/SimpleModel.scala
+++ b/core/src/test/scala/co.blocke.scalaJack/v4/SimpleModel.scala
@@ -1,7 +1,9 @@
 package co.blocke.scalajack
 package test.v4
 
+import json.JsonKind
 import org.joda.time.DateTime
+import org.joda.time.format.DateTimeFormat
 
 trait Blah
 case class Foo(
@@ -88,6 +90,14 @@ case class Address(street:String, zip:Int)
 case class Pristine( name:String, age:Int, stuff:Option[Boolean], addr:Address )
 
 class CustomVC(val underlying: DateTime) extends AnyVal
+object CustomVC extends ValueClassCustom {
+	def read:PartialFunction[(KindMarker,_), Any] = {
+	  case (jk:JsonKind,js:String) => DateTimeFormat.forPattern("MMMM, yyyy").parseDateTime(js)
+	}
+	def render:PartialFunction[(KindMarker,_), Any] = {
+	  case (jk:JsonKind,dt:DateTime) => '"'+DateTimeFormat.forPattern("MMMM, yyyy").print(dt)+'"'
+	}
+}
 case class SomethingSpecial( what:String, when:CustomVC )
 
 // Test view/splice

--- a/core/src/test/scala/co.blocke.scalaJack/v4/SimpleTests.scala
+++ b/core/src/test/scala/co.blocke.scalaJack/v4/SimpleTests.scala
@@ -256,15 +256,10 @@ class SimpleTestSpec extends FunSpec with GivenWhenThen with BeforeAndAfterAll {
 		}
 		describe("Support Custom JSON for Value Class") {
 			it("Must read & render custom JSON for value class") {				
-				val handler = ValClassHandler(
-					(s) => DateTimeFormat.forPattern("MMMM, yyyy").parseDateTime(s.asInstanceOf[String]),
-					(v) => '"'+DateTimeFormat.forPattern("MMMM, yyyy").print(v.asInstanceOf[DateTime])+'"'
-					)
 				val ss = SomethingSpecial("hey", new CustomVC(new DateTime(2015,7,1,0,0)))
-				val vc = VisitorContext().copy(valClassHandlers = Map("default"->Map("co.blocke.scalajack.test.v4.CustomVC"->handler)))
-				val js = sjJS.render(ss,vc)
+				val js = sjJS.render(ss)
 				js should equal("""{"what":"hey","when":"July, 2015"}""")
-				(sjJS.read[SomethingSpecial](js.toString,vc) == ss) should be(true)
+				(sjJS.read[SomethingSpecial](js.toString) == ss) should be(true)
 			}
 		}
 		describe("Type Hint Handling") {

--- a/core/src/test/scala/co.blocke.scalajack/v4/CustomSpec.scala
+++ b/core/src/test/scala/co.blocke.scalajack/v4/CustomSpec.scala
@@ -1,0 +1,76 @@
+package co.blocke.scalajack
+package test.v4
+
+import json.JsonKind
+import org.scalatest.{ FunSpec, GivenWhenThen, BeforeAndAfterAll }
+import org.scalatest.Matchers._
+import scala.language.postfixOps
+import scala.util.Try
+import org.joda.time.{DateTime,DateTimeZone}
+import org.joda.time.format._
+
+object ISOTime extends ValueClassCustom {
+	def read:PartialFunction[(KindMarker,_), Any] = {
+	  case (jk:JsonKind,js:String) => ISODateTimeFormat.dateTime().parseDateTime(js)
+	}
+	def render:PartialFunction[(KindMarker,_), Any] = {
+	  case (jk:JsonKind,iso:DateTime) => '"'+ISODateTimeFormat.dateTime().withZoneUTC().print(iso)+'"'
+	}
+}
+class ISOTime( val dt:DateTime ) extends AnyVal
+
+object CCNum extends ValueClassCustom {
+	def read:PartialFunction[(KindMarker,_), Any] = {
+	  case (jk:JsonKind,js:String) => js.replaceAllLiterally("-","")
+	}
+	def render:PartialFunction[(KindMarker,_), Any] = {
+	  case (jk:JsonKind,s:String) => '"'+s.grouped(4).toList.mkString("-")+'"'
+	}
+}
+class CCNum( val s:String ) extends AnyVal
+case class TestTime( period:ISOTime, cc:CCNum, num:Numa )
+
+class Numa( val s:String ) extends AnyVal
+
+class CustomSpec extends FunSpec {
+	val sjJS  = ScalaJack()
+	val vc_nc_v  = VisitorContext().copy(isCanonical = false, isValidating = true) 
+	val vc_c_v   = VisitorContext().copy(isValidating = true) 
+	val vc_nc_nv = VisitorContext().copy(isCanonical = false) 
+	// No vc = c_nv canonical (c) and non-validating (nv)
+
+	object JSMaster {
+		val a = """{"period":"2015-09-18T04:00:00.000Z","cc":"1234-5678-9012-3456","num":"123"}"""
+	}
+
+	object ScalaMaster {
+		val a = TestTime(new ISOTime( ISODateTimeFormat.dateTime().parseDateTime("2015-09-18T04:00:00.000Z") ), new CCNum("1234567890123456"), new Numa("123"))
+	}
+
+	describe("=========================\n| -- Custom VC Tests -- |\n=========================") {
+		it("Render Tests - CNV") {
+			sjJS.render( ScalaMaster.a ) should be( JSMaster.a )
+		}
+		it( "Read custom value class - CNV" ) {
+			sjJS.read[TestTime]( JSMaster.a ) should be( ScalaMaster.a )
+		}
+		it("Render Tests - NCNV") {
+			sjJS.render( ScalaMaster.a,vc_nc_nv ) should be( JSMaster.a )
+		}
+		it( "Read custom value class - NCNV" ) {
+			sjJS.read[TestTime]( JSMaster.a, vc_nc_nv ) should be( ScalaMaster.a )
+		}
+		it("Render Tests - CV") {
+			sjJS.render( ScalaMaster.a,vc_c_v ) should be( JSMaster.a )
+		}
+		it( "Read custom value class - CV" ) {
+			sjJS.read[TestTime]( JSMaster.a, vc_c_v ) should be( ScalaMaster.a )
+		}
+		it("Render Tests - NCV") {
+			sjJS.render( ScalaMaster.a,vc_nc_v ) should be( JSMaster.a )
+		}
+		it( "Read custom value class - NCV" ) {
+			sjJS.read[TestTime]( JSMaster.a, vc_nc_v ) should be( ScalaMaster.a )
+		}
+	}
+}

--- a/mongo/src/main/scala/co.blocke.scalajack/Mongo.scala
+++ b/mongo/src/main/scala/co.blocke.scalajack/Mongo.scala
@@ -1,5 +1,6 @@
 package co.blocke.scalajack
 
+import json.JsonKind
 import scala.collection.mutable.LinkedHashMap
 import scala.language.implicitConversions
 import org.mongodb.scala._
@@ -13,15 +14,14 @@ package object mongo {
 }
 import mongo._
 
-// Custom type
-case class ObjectIdType(name:String) extends CustomType {
-	val renderers = Map(  // ObjectId -> <something>
-		"default" -> ((a:Any) => "\""+a.asInstanceOf[BsonObjectId].getValue.toString+"\""),
-		"mongo"   -> ((a:Any) => a)
-		)
-	val readers   = Map(
-		"default" -> ((a:Any) => BsonObjectId(a.toString)),
-		"mongo"   -> ((a:Any) => a)
-		)
-	def dup = this.copy()
+class ObjectId( val bsonObjectId:BsonObjectId ) extends AnyVal
+object ObjectId extends ValueClassCustom {
+	def read:PartialFunction[(KindMarker,_), Any] = {
+	  case (jk:JsonKind,js:String) => BsonObjectId(js)
+	  case (mk:MongoKind,boid:BsonObjectId) => boid
+	}
+	def render:PartialFunction[(KindMarker,_), Any] = {
+	  case (jk:JsonKind,boid:BsonObjectId) => '"'+boid.getValue.toString+'"'
+	  case (mk:MongoKind,boid:BsonObjectId) => boid
+	}
 }

--- a/mongo/src/test/scala/co.blocke.scalajack/ExtraSpec.scala
+++ b/mongo/src/test/scala/co.blocke.scalajack/ExtraSpec.scala
@@ -273,15 +273,10 @@ class ExtraSpec extends FunSpec with GivenWhenThen with BeforeAndAfterAll {
 				}
 				it("Must read & render custom JSON for value class") {
 					val sj = ScalaJack()
-					val handler = ValClassHandler(
-						(s) => DateTimeFormat.forPattern("MMMM, yyyy").parseDateTime(s.asInstanceOf[String]),
-						(v) => '"'+DateTimeFormat.forPattern("MMMM, yyyy").print(v.asInstanceOf[DateTime])+'"'
-						)
 					val ss = SomethingSpecial("hey", new CustomVC(new DateTime(2015,7,1,0,0)))
-					val vc = VisitorContext().copy(valClassHandlers = Map("default"->Map("co.blocke.scalajack.test.CustomVC"->handler)))
-					val js = sj.render(ss,vc)
+					val js = sj.render(ss)
 					js should equal("""{"what":"hey","when":"July, 2015"}""")
-					(sj.read[SomethingSpecial](js.toString,vc) == ss) should be(true)
+					(sj.read[SomethingSpecial](js.toString) == ss) should be(true)
 				}
 			}
 		}

--- a/mongo/src/test/scala/co.blocke.scalajack/TestModel.scala
+++ b/mongo/src/test/scala/co.blocke.scalajack/TestModel.scala
@@ -3,6 +3,10 @@ package test
 
 import org.bson.types.ObjectId
 import org.joda.time.DateTime
+import org.joda.time.format._
+import org.mongodb.scala.bson._
+import json.JsonKind
+import mongo.MongoKind
 
 object Num extends Enumeration {
 	val A,B,C = Value
@@ -94,7 +98,7 @@ case class Six(
 	)
 
 case class Seven(
-	@DBKey _id:org.bson.BsonObjectId,
+	@DBKey _id:co.blocke.scalajack.ObjectId,
 	two : Two
 	)
 
@@ -205,5 +209,15 @@ case class WithDefaults(
 	pet      : Pet = NicePet(Dog("Fido"),"bones")
 	)
 
+object CustomVC extends ValueClassCustom {
+	def read:PartialFunction[(KindMarker,_), Any] = {
+	  case (jk:JsonKind,js:String) => DateTimeFormat.forPattern("MMMM, yyyy").parseDateTime(js)
+	  case (mk:MongoKind,bdt:BsonDateTime) => new DateTime(bdt.getValue)
+	}
+	def render:PartialFunction[(KindMarker,_), Any] = {
+	  case (jk:JsonKind,dt:DateTime) => '"'+DateTimeFormat.forPattern("MMMM, yyyy").print(dt)+'"'
+	  case (mk:MongoKind,dt:DateTime) => BsonDateTime(dt.toDate)
+	}
+}
 class CustomVC(val underlying: DateTime) extends AnyVal
 case class SomethingSpecial( what:String, when:CustomVC )


### PR DESCRIPTION
The previous way to render or read custom output from a value class was to use a "hook" by classname in the VisitorContext.  This was unnecessarily clunky so now we'll use a companion object implementing PartialFunctions for read and render.  See tests for examples.