### PR TITLE
Enriched tokenizer to ready-candidate state

### DIFF
--- a/core/src/main/scala/co.blocke.scalaJack/flexjson/EmptyReader.scala
+++ b/core/src/main/scala/co.blocke.scalaJack/flexjson/EmptyReader.scala
@@ -8,6 +8,7 @@ object EmptyReader extends Reader {
   override def read(expected: TokenType): Unit = ???
 
   override def readString(): String = ???
+  override def readIdentifier(): String = ???
 
   override def tokenText: String = ???
 

--- a/core/src/main/scala/co.blocke.scalaJack/flexjson/Reader.scala
+++ b/core/src/main/scala/co.blocke.scalaJack/flexjson/Reader.scala
@@ -19,6 +19,7 @@ trait Reader {
   def read(expected: TokenType): Unit
 
   def readString(): String
+  def readIdentifier(): String
 
   def skipValue(): Unit = {
     peek match {
@@ -49,6 +50,8 @@ trait Reader {
   }
 
   def tokenText: String
+
+  def hasNext: Boolean = peek != TokenType.End  // differentiate end-of-parsing from end of object/array
 
   def hasMoreElements: Boolean = peek != TokenType.EndArray
 

--- a/core/src/main/scala/co.blocke.scalaJack/flexjson/TokenReader.scala
+++ b/core/src/main/scala/co.blocke.scalaJack/flexjson/TokenReader.scala
@@ -25,6 +25,10 @@ class TokenReader(override val source: Array[Char],
     read(expected = TokenType.String)
     tokenText
   }
+  override def readIdentifier(): String = {
+    read(expected = TokenType.Identifier)
+    tokenText
+  }
 
   override def tokenText: String =
     new String(source, tokenOffsets(position), tokenLengths(position))

--- a/core/src/main/scala/co.blocke.scalaJack/flexjson/TokenType.scala
+++ b/core/src/main/scala/co.blocke.scalaJack/flexjson/TokenType.scala
@@ -11,7 +11,11 @@ object TokenType extends Enumeration {
       Identifier,
       Number,
       String,
+      True,
+      False,
+      Null,
       NameSeparator,
       ValueSeparator,
-      InsignificantWhitespace = Value
+      InsignificantWhitespace,
+      End = Value
 }

--- a/core/src/main/scala/co.blocke.scalaJack/flexjson/Tokenizer.scala
+++ b/core/src/main/scala/co.blocke.scalaJack/flexjson/Tokenizer.scala
@@ -4,16 +4,20 @@ import co.blocke.scalajack.flexjson.TokenType.TokenType
 
 class Tokenizer {
 
-  def tokenize(source: Array[Char], offset: Int, length: Int): TokenReader = {
+  def tokenize(source: Array[Char], offset: Int, length: Int, capacity:Int = 1024): TokenReader = {
     val maxPosition = offset + length
     var position = offset
 
-    val capacity = 1024
     val tokenTypes = new Array[TokenType](capacity)
     val tokenOffsets = new Array[Int](capacity)
     val tokenLengths = new Array[Int](capacity)
 
     var numberOfTokens = 0
+    var isIdentifier = false
+    val CTX_OBJ   : Byte = 1
+    val CTX_ARRAY : Byte = 2
+    val ctxStack = new Array[Byte](256)
+    var ctxPtr   = -1
 
     @inline def appendToken(tokenType: TokenType, tokenOffset: Int, tokenLength: Int): Unit = {
       val i = numberOfTokens
@@ -28,23 +32,30 @@ class Tokenizer {
 
     @inline def isSubsequentIdentifierChar(ch: Char): Boolean = ('a' <= ch && ch <= 'z') || ('A' <= ch && ch <= 'Z') || ('0' <= ch && ch <= '9') || ch == '_'
 
-    @inline def isIntegerChar(ch: Char): Boolean = '0' <= ch && ch <= '9'
+    @inline def isIntegerChar(ch: Char): Boolean = ('0' <= ch && ch <= '9') || ch == '.' || ch == '-' || ch == '+' || ch == 'e' || ch == 'E'
 
     while (position < maxPosition) {
       source(position) match {
         case '{' ⇒
+          ctxPtr += 1  // stack push
+          ctxStack(ctxPtr) = CTX_OBJ
           appendToken(TokenType.BeginObject, position, 1)
           position += 1
+          isIdentifier = true
 
         case '}' ⇒
+          ctxPtr -= 1  // stack pop
           appendToken(TokenType.EndObject, position, 1)
           position += 1
 
         case '[' ⇒
+          ctxPtr += 1  // stack push
+          ctxStack(ctxPtr) = CTX_ARRAY
           appendToken(TokenType.BeginArray, position, 1)
           position += 1
 
         case ']' ⇒
+          ctxPtr -= 1  // stack pop
           appendToken(TokenType.EndArray, position, 1)
           position += 1
 
@@ -53,8 +64,10 @@ class Tokenizer {
 
         case ',' ⇒
           position += 1
+          if( ctxStack(ctxPtr) == CTX_OBJ )  // , inside object is a field separator... identifier expected
+            isIdentifier = true
 
-        case '\n' ⇒
+        case ' ' | '\n' | '\t' ⇒ // skip whitespace
           position += 1
 
         case '"' ⇒
@@ -63,37 +76,48 @@ class Tokenizer {
           val start = position
 
           while (source(position) != '"') {
-            position += 1
+            if(source(position) == '\\') {
+              position += 2
+            }
+            else
+              position += 1
           }
 
-          appendToken(TokenType.String, start, position - start)
+          if( isIdentifier ) {
+            appendToken(TokenType.Identifier, start, position - start)
+            isIdentifier = false
+          }
+          else 
+            appendToken(TokenType.String, start, position - start)
 
           position += 1 // Skip the trailing double-quote
 
-        case ch ⇒
-          if (isInitialIdentifierChar(ch)) {
-            val start = position
+        case 'n' ⇒  // HUGE assumption this is null, but checking would slow us down too much
+          appendToken(TokenType.Null, position, 4)
+          position += 4
+
+        case 't' ⇒  // HUGE assumption this is true, but checking would slow us down too much
+          appendToken(TokenType.True, position, 4)
+          position += 4
+
+        case 'f' ⇒  // HUGE assumption this is false, but checking would slow us down too much
+          appendToken(TokenType.False, position, 5)
+          position += 5
+
+        case ch if(isIntegerChar(ch)) ⇒
+          val start = position
+
+          while (isIntegerChar(source(position))) {
             position += 1
-
-            while (isSubsequentIdentifierChar(source(position))) {
-              position += 1
-            }
-
-            appendToken(TokenType.Identifier, start, position - start)
-          } else if (isIntegerChar(ch)) {
-            val start = position
-
-            while (isIntegerChar(source(position))) {
-              position += 1
-            }
-
-            appendToken(TokenType.Number, start, position - start)
-          } else {
-            throw new IllegalArgumentException(s"Unknown character: $ch")
           }
 
+          appendToken(TokenType.Number, start, position - start)
+
+        case ch =>
+          throw new IllegalArgumentException(s"Unknown character: $ch")
       }
     }
+    appendToken(TokenType.End, position, 1)
 
     new TokenReader(source, numberOfTokens, tokenTypes, tokenOffsets, tokenLengths)
   }

--- a/core/src/main/scala/co.blocke.scalaJack/flexjson/typeadapter/CaseClassTypeAdapter.scala
+++ b/core/src/main/scala/co.blocke.scalaJack/flexjson/typeadapter/CaseClassTypeAdapter.scala
@@ -44,7 +44,7 @@ case class CaseClassTypeAdapter[T](constructorMirror: MethodMirror,
     reader.beginObject()
 
     while (reader.hasMoreFields) {
-      val name = reader.readString()
+      val name = reader.readIdentifier()
 
       val optionalParameter = parametersByName.get(name)
       optionalParameter match {


### PR DESCRIPTION
For your consideration:  Beefed up tokenizer to something pretty close to fully-ready.  Produces full compliment of tokens including true, false, and null.  Nesting is accounted for (identifies inside of objects aren't confused with strings inside of lists).

The Reader is cool... maybe if needed we can think about mark/look-ahead/resume, for example to find type hint or something.

NOTE: I'm gonna work in exp2 pulling and PR to experimental, which will be your branch.  That way we won't clobber each other and can accept/reject ideas without causing a mess, so merge this PR if you like what I did to tokenizer, otherwise reject.

Run like this:

```
import co.blocke.scalajack.flexjson._
import co.blocke.scalajack._

object Sample extends App { 

  val js = """{"name":"Say \"Greg\"","me":[{"id":1},{"id":2}]}"""
  
  val tok = new Tokenizer
  val reader = tok.tokenize(js.toCharArray(), 0, js.length)
  
  while(reader.hasNext) {
    println(reader.read + " -> "+ fix(reader.tokenText))
  }
  
  def fix(s:String) = Unicode.unescape_perl_string(s)  // get's rid of different escaping consistently with tried 'n true perl approach
}
```

produces

```
BeginObject -> {
Identifier -> name
String -> Say "Greg"
Identifier -> me
BeginArray -> [
BeginObject -> {
Identifier -> id
Number -> 1
EndObject -> }
BeginObject -> {
Identifier -> id
Number -> 2
EndObject -> }
EndArray -> ]
EndObject -> }
```