### PR TITLE
Large Documents and Enum Ordinals 

### DIFF
--- a/core/src/main/scala/co.blocke.scalajack/csv/Tokenizer.scala
+++ b/core/src/main/scala/co.blocke.scalajack/csv/Tokenizer.scala
@@ -3,7 +3,7 @@ package csv
 
 import TokenType.TokenType
 
-class Tokenizer(val capacity: Int = 1024) {
+class Tokenizer(val capacity: Int = 102400) {
 
   def tokenize(source: Array[Char], offset: Int, length: Int, capacity: Int = 1024): CSVTokenReader = {
     val maxPosition = offset + length

--- a/core/src/main/scala/co.blocke.scalajack/typeadapter/EnumerationTypeAdapter.scala
+++ b/core/src/main/scala/co.blocke.scalajack/typeadapter/EnumerationTypeAdapter.scala
@@ -30,6 +30,12 @@ case class EnumerationTypeAdapter[E <: Enumeration](enum: E) extends TypeAdapter
           case Success(u) => u
           case Failure(u) => throw new java.util.NoSuchElementException(s"No value found in enumeration ${enum.getClass.getName} for ${reader.tokenText}" + "\n" + reader.showError())
         }
+      case TokenType.Number =>
+        Try(enum(reader.readInt())) match {
+          case Success(u) => u
+          case Failure(u) => throw new java.util.NoSuchElementException(s"No value found in enumeration ${enum.getClass.getName} for ${reader.tokenText}" + "\n" + reader.showError())
+        }
+
       case TokenType.Null => reader.readNull()
       case actual =>
         reader.read()

--- a/mongo/src/main/scala/co.blocke.scalajack/mongo/BsonParser.scala
+++ b/mongo/src/main/scala/co.blocke.scalajack/mongo/BsonParser.scala
@@ -11,9 +11,9 @@ class BsonParser {
   def parse(value: BsonValue): BsonReader = {
 
     var numberOfTokens = 0
-    val tokenTypes = new Array[TokenType](1024)
-    val strings = new Array[String](1024)
-    val values = new Array[BsonValue](1024)
+    val tokenTypes = new Array[TokenType](10240000)
+    val strings = new Array[String](10240000)
+    val values = new Array[BsonValue](10240000)
 
     @inline def appendString(tokenType: TokenType, string: String): Unit = {
       val i = numberOfTokens


### PR DESCRIPTION
I ran into a few issues parsing larger Mongo documents, in my case ~6MB.
Also ran into an issue where an enum type in my JSON is mapped with an ordinal, this Enum change allows to map a number to the ordinal of the respective Scala Enum.